### PR TITLE
fix: docs toc display when no children

### DIFF
--- a/app/pods/-ui/docs/table-of-contents/template.hbs
+++ b/app/pods/-ui/docs/table-of-contents/template.hbs
@@ -1,4 +1,4 @@
-{{#if entries}}
+{{#if entries.children}}
   {{#-ui/nav-list title='Contents' root=entries offset=100 as |node slug|}}
       <a href="#{{node.slug}}" class="toc-link {{if (and node.slug (eq tocPosition node.slug)) 'active'}} level-{{node.level}}" {{action 'scrollToTarget' node.slug}}>{{node.title}}</a>
   {{/-ui/nav-list}}

--- a/app/pods/docs/api/-page/component.js
+++ b/app/pods/docs/api/-page/component.js
@@ -1,4 +1,4 @@
-import { forEach, map, isEmpty } from 'lodash';
+import { map, isEmpty } from 'lodash';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { lookupApi } from 'denali/helpers/lookup-api';

--- a/mirage/serializers/version.js
+++ b/mirage/serializers/version.js
@@ -1,6 +1,7 @@
 import { JSONAPISerializer } from 'ember-cli-mirage';
 
 export default JSONAPISerializer.extend({
+  // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
   include: [ 'addon' ],
   serializeIds: 'always',
 });


### PR DESCRIPTION
Hide the TOC if there are no entries. Also fix some linting.